### PR TITLE
docstring_parser 0.16

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,0 @@
-upload_channels:
-  - sfe1ed40
-

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 538beabd0af1e2db0146b6bd3caa526c35a34d61af9fd2887f3a8a27a739aa6e
 
 build:
-  skip: True  # [py<36]
+  skip: True  # [py<38]
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 


### PR DESCRIPTION
> ## ☆ docstring_parser 0.16 ☆
> [Jira Ticket](https://anaconda.atlassian.net/browse/PKG-8013) 
[Upstream](https://github.com/rr-/docstring_parser)
> 
> ### Changes
> * Removed `abs.yaml` as pkg needs to be on main
> * Added skip. for py<38