### PR TITLE
docstring_parser 0.15 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "docstring_parser" %}
-{% set version = "0.16" %}
+{% set version = "0.15" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 538beabd0af1e2db0146b6bd3caa526c35a34d61af9fd2887f3a8a27a739aa6e
+  sha256: 48ddc093e8b1865899956fcc03b03e66bb7240c310fac5af81814580c55bf682
 
 build:
   skip: True  # [py<38]


### PR DESCRIPTION
docstring_parser 0.15 

**Destination channel:** main

### Links

- [PKG-10170]
- dev_url:        https://github.com/rr-/docstring_parser/tree/0.15
- conda_forge:    https://github.com/conda-forge/docstring_parser-feedstock
- pypi:           https://pypi.org/project/docstring_parser/0.15
- pypi inspector: https://inspector.pypi.io/project/docstring_parser/0.15

### Explanation of changes:

- new version number


[PKG-10170]: https://anaconda.atlassian.net/browse/PKG-10170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ